### PR TITLE
Migrate docs to DocumenterVitepress

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -3,17 +3,23 @@ name: Documentation
 on:
   push:
     branches:
-      - 'master'
-      - 'release-'
+      - 'main'
     tags: '*'
   pull_request:
 
+permissions:
+  contents: write
+  pages: write
+  id-token: write
+  statuses: write
+  pull-requests: read
+
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
 jobs:
   build:
-    permissions:
-      contents: write
-      pull-requests: read
-      statuses: write
     runs-on: macOS-latest
     steps:
       - uses: actions/checkout@v4
@@ -25,10 +31,10 @@ jobs:
         run: julia --project=docs/ -e 'using Pkg; Pkg.develop(PackageSpec(path=pwd())); Pkg.instantiate()'
       - name: Build and deploy
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # If authenticating with GitHub Actions token
-          DOCUMENTER_KEY: ${{ secrets.DOCUMENTER_KEY }} # If authenticating with SSH deploy key
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          DOCUMENTER_KEY: ${{ secrets.DOCUMENTER_KEY }}
           GKSwstype: 100
         run: julia --project=docs/ docs/make.jl
-      - uses: julia-actions/julia-uploadcodecov@latest
-        env:
-          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+      - name: Save cache on failure
+        uses: julia-actions/cache@v1
+        if: failure()

--- a/.gitignore
+++ b/.gitignore
@@ -6,4 +6,10 @@ docs/build/
 docs/src/tutorials/
 docs/src/howtos/
 docs/src/notebooks/
+
 settings.json
+settings.local.json
+
+node_modules/
+package-lock.json
+docs/package.json

--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -1,8 +1,11 @@
 [deps]
+AIBECS = "ace601d6-714c-11e9-04e5-89b7fad23838"
 Bijectors = "76274a88-744f-5084-9051-94815aaf08c4"
 DataFrames = "a93c6f00-e57d-5684-b7b6-d8193f3e46c0"
+Distances = "b4f34e82-e78d-54a5-968a-f98e89d6e8f7"
 Distributions = "31c24e10-a181-5473-b8eb-7969acd0382f"
 Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
+DocumenterVitepress = "4710194d-e776-4893-9690-8d956a29c365"
 Interpolations = "a98d9a8b-a2ab-59e6-89dd-64a1c18fca59"
 JLD2 = "033835bb-8acc-5ee8-8aae-3f567f8a3819"
 Literate = "98b081ad-f1c9-55d3-8b20-4c87d4299306"
@@ -15,3 +18,4 @@ Unitful = "1986cc42-f94f-5a68-af5c-568840ba703d"
 
 [compat]
 Documenter = "1"
+DocumenterVitepress = "0.1"

--- a/docs/lit/howtos/1_parameters.jl
+++ b/docs/lit/howtos/1_parameters.jl
@@ -16,6 +16,7 @@
 # As usual, make sure you are using AIBECS
 
 using AIBECS
+using DataFrames # required for `AIBECS.table` (loaded via package extension)
 
 # ## Abstract parameters type
 

--- a/docs/lit/tutorials/1_ideal_age.jl
+++ b/docs/lit/tutorials/1_ideal_age.jl
@@ -5,7 +5,7 @@
 
 # The tracer equation for the ideal age is
 #
-# $$\left(\partial_t + \mathbf{T}\right) \boldsymbol{a} = 1 - \frac{\boldsymbol{a}}{τ} \, (\boldsymbol{z} \le z_0),$$
+# $$\left(\partial_t + \mathbf{T}\right) \boldsymbol{a} = 1 - \frac{\boldsymbol{a}}{\tau} \, (\boldsymbol{z} \le z_0),$$
 #
 # where the sink term on the right clamps the age to $0$ at the surface (where $\boldsymbol{z} \le z_0$).
 # The smaller the timescale $\tau$, the quicker $\boldsymbol{a}$ is restored to $0$ at the surface.

--- a/docs/lit/tutorials/3_Pmodel.jl
+++ b/docs/lit/tutorials/3_Pmodel.jl
@@ -151,6 +151,7 @@ plothorizontalslice(POP .* w(z,p) * (mol/m^3*m/s) .|> mmol/yr/m^2, grd, depth=50
 # Now let's make our model a little fancier and use a fine topographic map to refine the remineralization profile.
 # For this, we will use the ETOPO dataset, which can be downloaded by AIBECS via
 
+using Distances, NCDatasets # required to activate the `AIBECSETOPOExt` extension
 f_topo = ETOPO.fractiontopo(grd)
 
 # `f_topo` is the fraction of sediments located in each wet box of the `grd` grid.

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -58,7 +58,6 @@ if get(ENV, "CI", "false") == "true"
     deploydocs(
         repo = "github.com/JuliaOcean/AIBECS.jl.git",
         push_preview = true,
-        target = joinpath(@__DIR__, "build", "final_site"),
     )
 end
 

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -1,12 +1,10 @@
 using Documenter
+using DocumenterVitepress
 
 # Ensure that the DataDeps download work remotely
 ENV["JULIA_DEBUG"] = "Documenter"
 ENV["DATADEPS_ALWAYS_ACCEPT"] = true
 ENV["GKSwstype"] = "100"
-
-deployconfig = Documenter.auto_detect_deploy_system()
-Documenter.post_status(deployconfig; type="pending", repo="github.com/JuliaOcean/AIBECS.jl.git")
 
 using Literate
 using AIBECS
@@ -34,6 +32,7 @@ pages(folder) = [joinpath(folder, f) for f in readdir(joinpath(src, folder)) if 
 makedocs(
     sitename="AIBECS.jl",
     doctest = false, # TODO guessing I should remove that when actually deploying?
+    draft = get(ENV, "DRAFT", "false") == "true", # DRAFT=true skips @example/@repl/@setup/@eval blocks for fast markdown iteration
     # options
     modules = [AIBECS],
     # organisation
@@ -44,23 +43,44 @@ makedocs(
         "Explanation" => pages("explanation"),
         "Reference" => pages("reference")
         ],
-    warnonly = true,
-    format = Documenter.HTML(prettyurls = true),
+    warnonly = false,
+    format = DocumenterVitepress.MarkdownVitepress(
+        repo = "https://github.com/JuliaOcean/AIBECS.jl",
+        devbranch = "main",
+        devurl = "dev",
+        build_vitepress = get(ENV, "CI", "false") == "true",
+    ),
     remotes = nothing
 )
 
-# Deploy
-deploydocs(
-    repo = "github.com/JuliaOcean/AIBECS.jl.git",
-    push_preview = true
-)
-
+# Deploy (only on CI — locally there is nothing to deploy to)
+if get(ENV, "CI", "false") == "true"
+    deploydocs(
+        repo = "github.com/JuliaOcean/AIBECS.jl.git",
+        push_preview = true,
+        target = joinpath(@__DIR__, "build", "final_site"),
+    )
+end
 
 #=
-To edit locally, make sure execute is set to false and run
+To render and preview the docs locally:
 
-using LiveServer
-servedocs(literate=joinpath("docs", "lit"), doc_env=true)
+Recommended — VitePress dev server with hot reload (DocumenterVitepress-native):
+    1. julia --project=docs -e 'include("docs/make.jl")'    # generates VitePress sources
+       (locally `build_vitepress` is automatically false — see the format above —
+       so this step skips the production build and just emits the sources.)
+    2. julia --project=docs -e 'using DocumenterVitepress; DocumenterVitepress.dev_docs("docs/build")'
+    Browser opens at http://localhost:5173 with hot module reload.
+    On any src/ edit: re-run step 1; the browser auto-refreshes.
 
-from the root of the package in development
+Fast markdown-only iteration (skip @example/@repl/@setup/@eval evaluation):
+    DRAFT=true julia --project=docs -e 'include("docs/make.jl")'
+    Code blocks render as plain code — useful when you only want to check
+    page structure, prose, layout, or link targets. Drop `DRAFT=true` to
+    evaluate code blocks again.
+
+Note on `LiveServer.servedocs`: it auto-rebuilds on src/ changes but cannot
+preview a VitePress site correctly (asset paths are absolute under
+/AIBECS.jl/, and servedocs serves docs/build/ rather than the rendered
+docs/build/final_site/). Use `dev_docs` instead for visual preview.
 =#

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -1,10 +1,41 @@
 ```@raw html
-<img src="https://user-images.githubusercontent.com/4486578/60554111-8fc27400-9d79-11e9-9ca7-6d78ee89ea70.png" alt="logo" title="AIBECS_logo" align="middle" width="50%"/>
+---
+layout: home
+
+hero:
+  name: AIBECS.jl
+  text:
+  tagline: Algebraic Implicit Biogeochemistry Elemental Cycling System
+  image:
+    src: /assets/logo.png
+    alt: AIBECS logo
+  actions:
+    - theme: brand
+      text: Get Started
+      link: /tutorials/1_ideal_age
+    - theme: alt
+      text: View on GitHub
+      link: https://github.com/JuliaOcean/AIBECS.jl
+
+features:
+  - icon: 📖
+    title: Tutorials
+    details: Step-by-step introductions to AIBECS, from ideal age to coupled models.
+    link: /tutorials/1_ideal_age
+  - icon: 🧭
+    title: How-to Guides
+    details: Goal-oriented walk-throughs for specific tasks like plotting and fluxes.
+    link: /howtos/1_parameters
+  - icon: 💡
+    title: Explanation
+    details: In-depth discussion of the concepts behind AIBECS.
+    link: /explanation/1_concept
+  - icon: 📚
+    title: Reference
+    details: Function docstrings and API reference.
+    link: /reference/functions
+---
 ```
-
-# [AIBECS.jl](https://github.com/JuliaOcean/AIBECS.jl)
-
-The **Algebraic Implicit Biogeochemistry Elemental Cycling System**
 
 !!! note
     If you are using the AIBECS for the first time, you must add it to your Julia environment, by typing
@@ -12,43 +43,6 @@ The **Algebraic Implicit Biogeochemistry Elemental Cycling System**
     ]add AIBECS
     ```
     at the REPL.
-
-This documentation is organized in 4 parts:
-
-#### 1. Tutorials
-
-If you want to try AIBECS for the first time, this is where you should start.
-
-- The [ideal age tutorial](@ref idealage) is a good place to start.
-    Generate a simple linear model of an idealized tracer in a few lines of code.
-- The [radiocarbon tutorial](@ref radiocarbon) is a little bit more involved, with some nonlinearities and more advanced use of AIBECS features and syntax.
-- The [coupled PO₄–POP model tutorial](@ref P-model) couples 2 interacting tracers, dissolved phosphate and particulate organic phosphorus (POP).
-- The [dust model tutorial](@ref dust-model) simulates some fictitious metals being injected at the ocean–atmosphere interface and being reversibly scavenged.
-- The [river discharge tutorial](@ref riverdischarge) similarly simulates another fictitious radioactive tracer that is injected in the ocean by rivers and that decays away as time passes.
-- The [groundwater discharge tutorial](@ref groundwater-discharge) is almost identical to the riverdischarge tutorial, except it uses groundwater discharge data.
-
-#### 2. How-to guides
-
-Here you will find goal-oriented walk-through's.
-
-- [Parameters guide](@ref parameters)
-- [Plotting basic things](@ref plots)
-- [Plotting cruise/transects data](@ref cruiseplots)
-- [Estimate fluxes](@ref fluxes)
-- How to simulate, i.e., solve or timestep your model (coming soon!)
-- How to optimize parameters (coming soon!)
-- How to simulate sinking particles (coming soon!)
-
-#### 3. Explanation/discussion
-
-Here you will find more general discussions and explanations surrounding the AIBECS.
-
-- [The concept of the AIBECS](@ref concept)
-- [Tracer transport operators](@ref tracer-transport-operators)
-
-#### 4. Reference
-
-This section contains the docstrings of (almost all) the functions available in AIBECS.
 
 ----
 

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -7,7 +7,7 @@ hero:
   text:
   tagline: Algebraic Implicit Biogeochemistry Elemental Cycling System
   image:
-    src: /assets/logo.png
+    src: /logo.png
     alt: AIBECS logo
   actions:
     - theme: brand

--- a/ext/AIBECSRecipesBaseExt.jl
+++ b/ext/AIBECSRecipesBaseExt.jl
@@ -7,6 +7,8 @@ using OceanGrids
 using Unitful
 using Unitful: °, ustrip
 
+import AIBECS: ratioatstation, ratioatstation!, plotstencil, plotstencil!
+
 const lonticks = (-180:30:360, ["180°", "", "120°W", "", "60°W", "", "0°", "", "60°E", "", "120°E", "", "180°", "", "120°W", "", "60°W", "", "0°"])
 const latticks = (-90:30:90, ["SP", "60°S", "30°S", "EQ", "30°N", "60°N", "NP"])
 function prettyticks(axis, defaultticks)

--- a/src/diagnostics.jl
+++ b/src/diagnostics.jl
@@ -94,8 +94,7 @@ a Gaussian Kernel for values, but conserving mass.
 This matrix can also likely be used as a covariance matrix for observations in a Bayesian framework.
 """
 function smooth_operator(grd, T; σs=(1.0, 1.0, 0.25))
-    st = stencil(grd, T)
-    weight(dir) = Kernel.gaussian(σs)[dir]
+    weight(dir) = exp(-sum((Tuple(dir) ./ σs) .^ 2) / 2)
     Isym, Jsym, _, _ = symmetric_IJVVᵀ(T)
     dirs = directions(Isym, Jsym, grd)
     A = sparse(Isym, Jsym, weight.(dirs))

--- a/src/plot_recipes.jl
+++ b/src/plot_recipes.jl
@@ -43,6 +43,11 @@ function plotdepthprofile! end
 
 function plottransect end
 
+function ratioatstation end
+function ratioatstation! end
+function plotstencil end
+function plotstencil! end
+
 export plothorizontalslice, plothorizontalslice!, surfacemap, surfacemap!,
     plot∫dz, plot∫dz!, plotverticalintegral, plotverticalintegral!,
     plotverticalmean, plotverticalaverage,
@@ -54,4 +59,6 @@ export plothorizontalslice, plothorizontalslice!, surfacemap, surfacemap!,
     plot∫dxdy, plot∫dxdy!, plothorizontalintegral, plothorizontalintegral!,
     plothorizontalmean, plothorizontalmean!, plothorizontalaverage, plothorizontalaverage!,
     plotdepthprofile, plotdepthprofile!,
-    plottransect
+    plottransect,
+    ratioatstation, ratioatstation!,
+    plotstencil, plotstencil!


### PR DESCRIPTION
Switches the documentation pipeline from Documenter.HTML to a VitePress frontend via DocumenterVitepress.jl, with a hero-style landing page and an updated GitHub Pages CI workflow.

Also fixes a few regressions exposed by the stricter doc evaluation that the previous build masked:

- src/diagnostics.jl: smooth_operator referenced Kernel.gaussian after ImageFiltering was dropped during the package extensions migration. Replaced with an inline Gaussian (the mass-conservation step normalizes the kernel anyway).
- src/plot_recipes.jl + ext/AIBECSRecipesBaseExt.jl: ratioatstation, ratioatstation!, plotstencil, plotstencil! were defined only inside the Recipes extension and never exposed on the AIBECS namespace. Added stubs in plot_recipes.jl and import them in the extension so the @userplot macro adds methods to the public functions, matching the existing pattern for plottransect / surfacemap.
- docs/lit/howtos/1_parameters.jl: added `using DataFrames` (required to activate AIBECSDataFramesExt which provides AIBECS.table).
- docs/lit/tutorials/3_Pmodel.jl: added `using Distances, NCDatasets` before ETOPO.fractiontopo(grd) to activate AIBECSETOPOExt.

The make.jl build is gated so production VitePress builds and deploydocs only run on CI; locally the build emits VitePress sources suitable for `DocumenterVitepress.dev_docs("docs/build")`. A DRAFT=true env var skips @example evaluation for fast markdown iteration.