### PR TITLE
ci: deploy docs via GitHub Actions, materialising symlinks for VitePress

### DIFF
--- a/.github/workflows/DeployDocs.yml
+++ b/.github/workflows/DeployDocs.yml
@@ -1,0 +1,76 @@
+# Adapted from
+# https://github.com/LuxDL/DocumenterVitepress.jl/commit/18d2bf4a3f0288c54a04c3aab2c9d9e940cd5142
+# (which itself comes from the Lux.jl deployment strategy).
+#
+# Why this exists: DocumenterVitepress hardcodes the version path (e.g. /AIBECS.jl/v0.16.1/)
+# into both the asset URLs and VitePress's __VP_SITE_DATA__.base in the generated bundle.
+# When gh-pages contains a symlink like `stable -> v0.16.1`, GitHub Pages serves the
+# symlinked content under /stable/, but VitePress's hardcoded base /v0.16.1/ no longer
+# matches the URL the user is on, so the SPA hydrates into its own 404 page.
+#
+# Fix: after every push to gh-pages, replace each symlink with a real directory copy,
+# then sed-rewrite the original target name to the symlink name inside the copied files
+# so the hardcoded base agrees with the URL. Then publish via actions/deploy-pages.
+#
+# Prerequisite: GitHub Pages source must be set to "GitHub Actions" (not "Deploy from
+# branch") in repo Settings -> Pages, otherwise this workflow's output is ignored and
+# GitHub keeps serving the raw gh-pages branch.
+
+name: Deploy GitHub Pages
+
+on:
+  # Runs on pushes targeting the default branch
+  push:
+    branches:
+      - gh-pages
+
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+# Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+# Allow only one concurrent deployment, skipping runs queued between the run in-progress and latest queued.
+# However, do NOT cancel in-progress runs as we want to allow these production deployments to complete.
+concurrency:
+  group: "pages"
+  cancel-in-progress: false
+
+jobs:
+  # Build job
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: "gh-pages"
+          fetch-depth: 0 # Not needed if lastUpdated is not enabled
+      - name: Setup Pages
+        uses: actions/configure-pages@v5
+      - name: Fix Symlinks for Vitepress
+        run: |
+          find -type l -exec bash -c 'dir="$0"; newlnk=${dir:2}; lnk="$(readlink -m "$0")"; orglnk=$(basename $lnk); echo "$newlnk <--> $orglnk"; rm "$0"; cp -r $lnk "$0"; cd "$0"; grep "$orglnk" . -lr | xargs sed -i "s/$orglnk/$newlnk/g"; cd ..' {} \;
+          ls -al;
+      - name: Build with Jekyll
+        uses: actions/jekyll-build-pages@v1
+        with:
+          source: ./
+          destination: ./_site
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+
+  # Deployment job
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
## Summary

Workaround for the DocumenterVitepress hydration-into-404 problem on \`/stable/\`, \`/latest/\`, \`/v0.16/\`, etc. — adapted verbatim from [LuxDL/DocumenterVitepress.jl@18d2bf4](https://github.com/LuxDL/DocumenterVitepress.jl/commit/18d2bf4a3f0288c54a04c3aab2c9d9e940cd5142).

## The problem

DocumenterVitepress hardcodes the version path (e.g. \`/AIBECS.jl/v0.16.1/\`) into both asset URLs and \`__VP_SITE_DATA__.base\` in the generated bundle. When \`gh-pages\` has \`stable -> v0.16.1\` as a symlink:

- GitHub Pages serves the symlinked content under \`/AIBECS.jl/stable/\` (HTTP 200, real HTML).
- But VitePress's hydration sees \`base = /v0.16.1/\` ≠ pathname \`/stable/\` and renders its in-app 404.

Result: every \`/stable/\` and \`/latest/\` link in the wild visually 404s even though the static content is there.

## The fix

This workflow runs on every push to \`gh-pages\` (plus manual dispatch):

1. Walks \`gh-pages\` and replaces each symlink with a real directory copy (\`rm stable; cp -r v0.16.1 stable\`).
2. Inside the copy, \`sed\`-rewrites all references to the original target name to the symlink name. So \`stable/index.html\`'s \`__VP_SITE_DATA__.base\` becomes \`/AIBECS.jl/stable/\` and all asset paths follow.
3. Bundles via \`actions/jekyll-build-pages\` and deploys via \`actions/deploy-pages\`.

## Prerequisite — manual, post-merge

**Repo Settings → Pages → Source must be flipped from "Deploy from a branch" to "GitHub Actions"** for this workflow's artifact to be what GitHub serves. Until that flip, the workflow runs but its output is ignored and GitHub keeps serving raw \`gh-pages\`.

Recommended sequence:
1. Merge this PR.
2. Trigger the workflow manually (\`workflow_dispatch\` against current \`gh-pages\`) and confirm the artifact build is green.
3. Flip Pages source to "GitHub Actions".
4. Hit \`/stable/\` to confirm it now hydrates correctly.

## Trade-offs

- **Artifact size grows** by ~17 doc-tree copies (\`stable\`, \`latest\`, \`v0.1\`–\`v0.16\` major-symlinks) — about 170 MB on top of the existing tree, well under the 1 GB GitHub Pages cap.
- **Two-stage publish**: doc push → \`gh-pages\` push → DeployDocs workflow → Pages serve. Adds ~1 min latency.

## Test plan

- [ ] Merge this PR.
- [ ] In the Actions tab, run \"Deploy GitHub Pages\" manually via \`workflow_dispatch\` and confirm both \`build\` and \`deploy\` jobs succeed.
- [ ] Inspect the build job's \"Fix Symlinks for Vitepress\" step output and confirm the symlinks are listed and rewritten.
- [ ] Switch Pages source to \"GitHub Actions\".
- [ ] Visit https://juliaocean.github.io/AIBECS.jl/stable/ in incognito and confirm the page hydrates without an in-app 404.

🤖 Generated with [Claude Code](https://claude.com/claude-code)