### PR TITLE
feat: CTKAlg solver API — retcode return + linear_cache warm-start

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "AIBECS"
 uuid = "ace601d6-714c-11e9-04e5-89b7fad23838"
-version = "0.18.0"
+version = "0.19.0"
 authors = ["Benoit Pasquier <briochemc@gmail.com>"]
 
 [deps]

--- a/src/CTKsolvers.jl
+++ b/src/CTKsolvers.jl
@@ -125,7 +125,7 @@ Method*, SIAM, Frontiers in Applied Mathematics 1.
 """
 function NewtonChordShamanskii(
         F, ∇ₓF, xinit, linsolve_alg, tc_cache;
-        preprint = "", maxItNewton = 50
+        preprint = "", maxItNewton = 50, linear_cache = nothing
     )
     if preprint ≠ ""
         println(preprint * "Solving F(x) = 0 (using Shamanskii Method)")
@@ -149,9 +149,18 @@ function NewtonChordShamanskii(
     NFᵢ = nrm(Fᵢ)   ;  NFᵢ₋₁ = NFᵢ
     δxᵢ = copy(xᵢ₋₁)
 
-    # LinearSolve cache: built once. `linsol.A = …` flips `isfresh = true` so
-    # the next `solve!` refactors; `linsol.b = …` reuses the factorization.
-    linsol = init(LinearProblem(∇ₓF(xinit), -copy(Fᵢ)), linsolve_alg)
+    # LinearSolve cache: built once unless the caller supplied one via
+    # `linear_cache`. `linsol.A = …` flips `isfresh = true` so the next
+    # `solve!` refactors; `linsol.b = …` reuses the factorization. A
+    # supplied cache is used as-is — the caller is expected to have set
+    # `cacheval` (the factors) and `isfresh = false` to skip the iter-1
+    # factorisation; Shamanskii's ratio check + Armijo's "old J → back off
+    # and refactor" branch are the safety net if the warm-start is stale.
+    linsol = if linear_cache === nothing
+        init(LinearProblem(∇ₓF(xinit), -copy(Fᵢ)), linsolve_alg)
+    else
+        linear_cache
+    end
     age = 0
     rShamᵢ = 0.0
     ArmijoFail = false
@@ -206,7 +215,7 @@ function NewtonChordShamanskii(
                 Fᵢ .= Fᵢ₋₁
             else # else if J is fresh it's a complete failure
                 preprint ≠ "" ? println("Complete Failure") : nothing
-                return xᵢ
+                return xᵢ, SciMLBase.ReturnCode.Unstable
             end
         end
 
@@ -236,7 +245,18 @@ function NewtonChordShamanskii(
         @printf("‖F(x)‖ = %.2e\n", NFᵢ)
     end
 
-    return xᵢ
+    # Mirror NonlinearSolveBase: prefer the termination cache's verdict (so
+    # callers see `StalledSuccess` / `Stalled` from `AbsNormSafeBest`),
+    # else `MaxIters` if the Newton budget ran out.
+    retcode = if terminated
+        tc_cache.retcode == SciMLBase.ReturnCode.Default ?
+            SciMLBase.ReturnCode.Success : tc_cache.retcode
+    elseif i ≥ maxItNewton
+        SciMLBase.ReturnCode.MaxIters
+    else
+        SciMLBase.ReturnCode.Default
+    end
+    return xᵢ, retcode
 end
 
 function print_marker(i)

--- a/src/overload_solve.jl
+++ b/src/overload_solve.jl
@@ -31,7 +31,8 @@ CTKAlg(; linsolve = UMFPACKFactorization()) = CTKAlg(linsolve)
           abstol = nothing,
           reltol = nothing,
           preprint = "",
-          maxItNewton = 50)
+          maxItNewton = 50,
+          linear_cache = nothing)
 
 Solves `prob` using an AIBECS-customized Newton–Chord–Shamanskii method with
 Armijo line search. Convergence is delegated to NonlinearSolveBase termination
@@ -40,6 +41,26 @@ modes — the default mirrors `NonlinearSolve`'s `:regular` algorithm default
 `abstol`/`reltol` to tighten or loosen, or pass any
 `AbstractNonlinearTerminationMode` (e.g. `NormTerminationMode(norm)`,
 `RelNormTerminationMode(norm)`) to swap criteria.
+
+# Warm-starting via `linear_cache`
+
+`linear_cache` (advanced) accepts a `LinearSolve.LinearCache` from a previous
+solve. When supplied it replaces the internal `init(LinearProblem(…))` call,
+so the caller's factorisation is reused on the first Newton iteration. This
+matters in two settings:
+
+1. Outer optimisers (e.g. `F1Method`, `Optimization.jl`) that already hold a
+   factorised Jacobian for the current parameter point — feeding it back in
+   skips the most expensive operation of the inner Newton solve.
+2. Parameter sweeps where adjacent grid cells share most of the Jacobian's
+   numerical content — the previous cell's factor is a useful warm-start.
+
+The caller is responsible for setting `linear_cache.A`,
+`linear_cache.cacheval`, and `linear_cache.isfresh` to a coherent triple
+before the call. The cache's RHS must be a vector (length `nb`). Shamanskii's
+ratio check + Armijo's line-search are the safety net if the supplied
+factors turn out to be too stale — a bad warm-start slows convergence by at
+most one Newton iteration before the factorisation is refreshed.
 """
 function SciMLBase.solve(
         prob::SciMLBase.AbstractSteadyStateProblem,
@@ -50,7 +71,8 @@ function SciMLBase.solve(
         abstol = nothing,
         reltol = nothing,
         preprint = "",
-        maxItNewton = 50
+        maxItNewton = 50,
+        linear_cache = nothing,
     )
     # Define the functions according to SciMLBase.SteadyStateProblem type
     p = prob.p
@@ -76,13 +98,12 @@ function SciMLBase.solve(
     # `alg.linsolve` is set eagerly to `UMFPACKFactorization()` by the default
     # constructor — see `CTKAlg(; linsolve = UMFPACKFactorization())` above —
     # so no `=== nothing` branch is needed here.
-    x_steady = NewtonChordShamanskii(
+    x_steady, retcode = NewtonChordShamanskii(
         F, ∇ₓF, x0, alg.linsolve, tc_cache;
-        preprint = preprint, maxItNewton = maxItNewton
+        preprint = preprint, maxItNewton = maxItNewton, linear_cache = linear_cache
     )
     resid = F(x_steady)
-    # Return the common SciMLBase solution type
-    return SciMLBase.build_solution(prob, alg, x_steady, resid; retcode = SciMLBase.ReturnCode.Success)
+    return SciMLBase.build_solution(prob, alg, x_steady, resid; retcode = retcode)
 end
 
 export solve, SteadyStateProblem, CTKAlg

--- a/test/solvers.jl
+++ b/test/solvers.jl
@@ -46,4 +46,48 @@ solver_cases = [
         residual = fun.f(s.u, testp, 0)
         @test norm(residual) ≤ 1.0e-8 * norm([residual; s.u])
     end
+
+    @testset "CTKAlg retcode" begin
+        testp = p
+        ssprob = SteadyStateProblem(fun, x, testp)
+
+        s_ok = solve(ssprob, CTKAlg())
+        @test SciMLBase.successful_retcode(s_ok.retcode)
+
+        s_short = solve(ssprob, CTKAlg(); maxItNewton = 1)
+        @test s_short.retcode == SciMLBase.ReturnCode.MaxIters
+    end
+
+    @testset "CTKAlg warm-start via linear_cache" begin
+        testp = p
+        ssprob = SteadyStateProblem(fun, x, testp)
+
+        # Cold solve as reference.
+        s_cold = solve(ssprob, CTKAlg())
+
+        # Build a vector-RHS LinearCache at the converged Jacobian and force
+        # factorisation. After solve!, isfresh = false and cacheval holds the
+        # UMFPACK factors — exactly the state a warm-start caller would set up.
+        lc = init(
+            LinearProblem(fun.jac(s_cold.u, testp), similar(s_cold.u)),
+            UMFPACKFactorization(),
+        )
+        solve!(lc)
+
+        # Same-point warm-start: residual is similarly small. State agreement
+        # is bounded by the solver tolerance (~1e-6 here) — both Newton runs
+        # terminate at a finite residual norm, not at machine precision, so
+        # iterates can drift at that scale.
+        s_warm = solve(ssprob, CTKAlg(); linear_cache = lc)
+        @test maximum(abs, fun.f(s_warm.u, testp, 0)) ≤ 1.0e-6
+        @test maximum(abs, s_warm.u - s_cold.u) ≤ 1.0e-5
+
+        # Nearby-parameter warm-start: re-solve at a perturbed p with the
+        # same (now slightly stale) factors. Shamanskii will refresh if the
+        # ratio check fires; either way convergence must still happen.
+        testp2 = AIBECS.reconstruct(TestParameters, 1.05 * vec(p))
+        ssprob2 = SteadyStateProblem(fun, s_cold.u, testp2)
+        s_warm2 = solve(ssprob2, CTKAlg(); linear_cache = lc)
+        @test maximum(abs, fun.f(s_warm2.u, testp2, 0)) ≤ 1.0e-6
+    end
 end


### PR DESCRIPTION
## Summary

Two related additions to the inner Newton solver, plus a matching 0.19.0 version bump:

### (a) Retcode return

`NewtonChordShamanskii` now returns `(x, retcode)` instead of a bare state vector. The retcode threads:

- the NonlinearSolveBase termination-cache verdict (`Success` / `StalledSuccess` / `Stalled`)
- `MaxIters` when the Newton budget runs out
- `Unstable` on Armijo complete-failure with a fresh Jacobian

`solve(::SteadyStateProblem, ::CTKAlg; …)` forwards this retcode into `build_solution` instead of hard-coding `ReturnCode.Success`.

**This is a breaking change** for any external caller that pattern-matched `NewtonChordShamanskii` as returning a single vector. The function is documented as AIBECS-internal but the breakage warrants the 0.19 bump.

### (b) `linear_cache` warm-start

New `linear_cache::LinearSolve.LinearCache` kwarg on `solve(::SteadyStateProblem, ::CTKAlg; …)` that bypasses the internal `init(LinearProblem(…))` call so callers (F1Method / parameter sweeps) can feed in a pre-factorised Jacobian. Shamanskii's ratio check + Armijo's old-J fallback are the safety net against stale factors.

## Test plan

- [x] `Pkg.test()` green locally (109/109)
- [x] New `CTKAlg retcode` testset passes (covers `Success` and `MaxIters` paths)
- [x] New `CTKAlg warm-start via linear_cache` testset passes (covers same-point and nearby-parameter warm-start)
- [x] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)
